### PR TITLE
Make module work in a node.js environment including tests

### DIFF
--- a/reflect.js
+++ b/reflect.js
@@ -1246,7 +1246,7 @@ Object.prototype.valueOf = function() {
 // ============= Reflection module =============
 // see http://wiki.ecmascript.org/doku.php?id=harmony:reflect_api
 
-global.Reflect = {
+var Reflect = global.Reflect = {
   getOwnPropertyDescriptor: function(target, name) {
     return Object.getOwnPropertyDescriptor(target, name);
   },
@@ -1697,7 +1697,7 @@ if (typeof StopIteration === "undefined") {
   global.StopIteration = {};
 }
 
-}(this, function(target, name) {
+}(typeof exports !== 'undefined' ? global : this, function(target, name) {
   // non-strict delete, will never throw
   return delete target[name];
 })); // function-as-module pattern

--- a/test/testProxies.js
+++ b/test/testProxies.js
@@ -36,6 +36,14 @@
  *
  */
 
+// for node.js
+if(typeof require === 'function') {
+  var load = require;
+  var print = function(msg) {
+    if(/^fail/.test(msg)) { console.error(msg); }
+    else { console.log(msg); }
+  }
+}
 load('../reflect.js');
 Proxy = Reflect.Proxy;
 


### PR DESCRIPTION
This patch does a simple test for a node.js environment and makes a few
changes. The Reflect module is exported to the global scope and the load
function is replaced with require. Use console api to print.
