### PR TITLE
Notifier fixes to match updated spec

### DIFF
--- a/examples/observer.js
+++ b/examples/observer.js
@@ -132,20 +132,16 @@ Observer = function Observer(Object) {
       if (target === undefined) { return undefined; }
       var changeObservers = _NotifierChangeObservers.get(notifier);
       if (changeObservers === undefined) { return undefined; }
-      // Q: should the changeRecord really define an 'object' prop?
-      // Can't the notifier tack it on automatically?
-      var object = changeRecord.object;
-      if (object !== target) {
-        throw new TypeError("change record object does not match notifier target");
-      }
       var type = changeRecord.type;
       if (typeof type !== "string") {
         throw new TypeError("change record type must be a string, given "+type);
       }
       var newRecord = Object.create(Object.prototype);
       for (var propName in changeRecord) {
+        if (propName == "object") { continue; }
         newRecord[propName] = changeRecord[propName];
       }
+      newRecord.object = target;
       // Q: perhaps no longer necessary -> newRecord doesn't leak
       Object.preventExtensions(newRecord);
       _EnqueueChangeRecord(newRecord, changeObservers);


### PR DESCRIPTION
Hi Tom,

I've been working with [Rafael Weinstein](https://github.com/rafaelw) on a [branch of v8](https://github.com/rafaelw/v8) and wrote some tests for our implementation there. Here are a few fixes to your proxy-based implementation to match both our impl and the spec (which has seen a few updates since notify() was last modified, it seems).

One of these is a straight-up bugfix (the code was looping over newRecord instead of the passed-in record).

Cheers,
Adam
