### PR TITLE
- allow the generic membrane handler to intercept function calls

### DIFF
--- a/examples/generic_membrane.js
+++ b/examples/generic_membrane.js
@@ -226,7 +226,15 @@
             var dryArgs = wetArgs.map(wetToDry);
             var dryThis = wetToDry(wetThis);
             try {
-              var dryResult = Reflect.apply(dryTarget, dryThis, dryArgs);            
+
+              var dryResult = null;
+
+              if (handler.onCall) {
+                  dryResult = handler.onCall(dryTarget, dryThis, dryArgs);
+              } else {
+                  dryResult = Reflect.apply(dryTarget, dryThis, dryArgs);
+              }
+
               var wetResult = dryToWet(dryResult);
               return wetResult;
             } catch (dryException) {


### PR DESCRIPTION
 e.g., throw an exception
