### PR TITLE
Fix patched Object.defineProperty to return proxy itself.

### DIFF
--- a/reflect.js
+++ b/reflect.js
@@ -1437,7 +1437,7 @@ Object.defineProperty = function(subject, name, desc) {
     if (success === false) {
       throw new TypeError("can't redefine property '"+name+"'");
     }
-    return success;
+    return subject;
   } else {
     return prim_defineProperty(subject, name, desc);
   }

--- a/test/testProxies.js
+++ b/test/testProxies.js
@@ -325,6 +325,18 @@ load('../reflect.js');
         });
     };
 
+  TESTS.testDefinePropertyReturnsProxy =
+    function(brokenProxy, emulatedProps, emulatedProto, success) {
+      success.x = true;
+      var result = Object.defineProperty(brokenProxy,'x',{
+        value: 2,
+        writable: true,
+        enumerable: true,
+        configurable: true
+      });
+      assert(result === brokenProxy, 'patched defineProperty returns proxy');
+    };
+
   TESTS.testNonConfigurableNoDelete =
     function(brokenProxy, emulatedProps, emulatedProto, success, target) {
       emulatedProps.x = {value:1, configurable:false};


### PR DESCRIPTION
`Object.defineProperty` should always return object it was used on, but patched version returned `sucess` (`true`) instead.