### PR TITLE
Add license field with SPDX expression.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "harmony",
     "es6"
   ],
+  "license": "(Apache-2.0 OR MPL-1.1)"
   "homepage": "https://github.com/tvcutsem/harmony-reflect",
   "typings": "index",
   "repository" : {


### PR DESCRIPTION
Hi @tvcutsem 😊!

I was missing the `license` field in the `package.json` file, hence I added it.

In the `LICENSE` file you state that this module is dual-licensed, I assume this means that I can choose which license to apply. If not, and if you meant that I have to pay attention to both licenses at the same time, the `OR` in the SPDX expression needs to be replaced by an `AND`.